### PR TITLE
Fix Geez numeral conversion

### DIFF
--- a/script.js
+++ b/script.js
@@ -198,7 +198,7 @@ function toGeez(num) {
 
     if (n >= 100) {
         const h = Math.floor(n / 100);
-        if (h > 1) result += digits[h];
+        if (h > 1) result += toGeez(h);
         result += hundred;
         n = n % 100;
     }


### PR DESCRIPTION
## Summary
- fix `toGeez()` to use recursion for hundreds

## Testing
- `node script.js` *(fails: window is not defined)*
- `node - <<'EOF'
function toGeez(num){if(num===0)return'0';const digits=['','፩','፪','፫','፬','፭','፮','፯','፰','፱'];const tens=['','፲','፳','፴','፵','፶','፷','፸','፹','፺'];const hundred='፻';const tenThousand='፼';let result='';let n=num;if(n>=10000){const t=Math.floor(n/10000);result+=toGeez(t)+tenThousand;n=n%10000;}if(n>=100){const h=Math.floor(n/100);if(h>1)result+=toGeez(h);result+=hundred;n=n%100;}if(n>=10){const t=Math.floor(n/10);result+=tens[t];n=n%10;}if(n>0){result+=digits[n];}return result;}console.log(toGeez(7517));
EOF

------
https://chatgpt.com/codex/tasks/task_e_684a6d61ee1c8320854c0b5fe2cb2fb7