### PR TITLE
Use responsive cards for calendar results

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,53 +63,79 @@
             </div>
         </div>
 
-        <div class="table-responsive">
-            <table class="table table-bordered table-striped table-hover mt-4">
-                <thead class="table-dark">
-                    <tr>
-                        <th>ስሌት</th>
-                       <th>ውጤት</th>
-                    </tr>
-                </thead>
-                <tbody id="resultTable">
-                    <tr>
-                        <td>ዓመተ አለም</td>
-                        <td id="ameteAlem"></td>
-                    </tr>
-                    <tr>
-                        <td>ወንጌላዊ</td>
-                        <td id="wengelawi"></td>
-                    </tr>
-                    <tr>
-                        <td>እንቁጣጣሽ</td>
-                        <td id="tinteQemer"></td>
-                    </tr>
-                    <tr>
-                        <td>መደብ</td>
-                        <td id="medeb"></td>
-                    </tr>
-                    <tr>
-                        <td>ወንበር</td>
-                        <td id="wenber"></td>
-                    </tr>
-                    <tr>
-                        <td>አበቅቴ</td>
-                        <td id="abektie"></td>
-                    </tr>
-                    <tr>
-                        <td>መጥቅእ</td>
-                        <td id="metqi"></td>
-                    </tr>
-                    <tr>
-                        <td>በዓለ መጥቅእ</td>
-                        <td id="bealeMetqi"></td>
-                    </tr>
-                    <tr>
-                        <td>መባጃ ሐመር(ነነዌ)</td>
-                        <td id="mebajaHamer"></td>
-                    </tr>
-                </tbody>
-            </table>
+        <div class="row mt-4" id="resultCards">
+            <div class="col-sm-6 col-lg-4 mb-3">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">ዓመተ አለም</h5>
+                        <p class="card-text" id="ameteAlem"></p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 col-lg-4 mb-3">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">ወንጌላዊ</h5>
+                        <p class="card-text" id="wengelawi"></p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 col-lg-4 mb-3">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">እንቁጣጣሽ</h5>
+                        <p class="card-text" id="tinteQemer"></p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 col-lg-4 mb-3">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">መደብ</h5>
+                        <p class="card-text" id="medeb"></p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 col-lg-4 mb-3">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">ወንበር</h5>
+                        <p class="card-text" id="wenber"></p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 col-lg-4 mb-3">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">አበቅቴ</h5>
+                        <p class="card-text" id="abektie"></p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 col-lg-4 mb-3">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">መጥቅእ</h5>
+                        <p class="card-text" id="metqi"></p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 col-lg-4 mb-3">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">በዓለ መጥቅእ</h5>
+                        <p class="card-text" id="bealeMetqi"></p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 col-lg-4 mb-3">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">መባጃ ሐመር(ነነዌ)</h5>
+                        <p class="card-text" id="mebajaHamer"></p>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <h3 class="mt-5">አጽዋማት እና በዓላት</h3>

--- a/script.js
+++ b/script.js
@@ -22,6 +22,13 @@ window.onload = function() {
     }
 };
 
+function updateResult(id, value) {
+    const el = document.getElementById(id);
+    if (el) {
+        el.textContent = value;
+    }
+}
+
 function calculateCurrentEthiopianYear() {
     const today = new Date(); // Get current date
     const gregorianYear = today.getFullYear(); // Current Gregorian year
@@ -50,13 +57,13 @@ function calculateCalendar() {
     // Step 1: Calculate Amete Alem
     const yearsBeforeChrist = 5500;
     const ameteAlem = yearsBeforeChrist + ethiopianYear;
-    document.getElementById('ameteAlem').innerText = formatNumber(ameteAlem);
+    updateResult('ameteAlem', formatNumber(ameteAlem));
 
     // Step 2: Calculate Evangelist (Wengelawi)
     const evangelists = ["ዮሐንስ", "ማቴዎስ", "ማርቆስ", "ሉቃስ"];
     const wengelawiIndex = ameteAlem % 4;
     const wengelawi = evangelists[wengelawiIndex];
-    document.getElementById('wengelawi').innerText = wengelawi;
+    updateResult('wengelawi', wengelawi);
 
     // Step 3: Calculate the correct day of New Year (Tinte Qemer)
     // ይህ አልሰራም፡፡
@@ -86,12 +93,12 @@ function calculateCalendar() {
     var tinteQemerDate = tinteQemerTable[tinteQemer]
     window.firstDayOfYear = tinteQemerDate;
 
-    document.getElementById('tinteQemer').innerText = `መስከረም ${formatNumber(1)} (${mapWeekDaysToAmharic(tinteQemerDate)})`;
+    updateResult('tinteQemer', `መስከረም ${formatNumber(1)} (${mapWeekDaysToAmharic(tinteQemerDate)})`);
 
-    document.getElementById('medeb').innerText   = formatNumber(medeb);
-    document.getElementById('wenber').innerText  = formatNumber(wenber);
-    document.getElementById('abektie').innerText = formatNumber(abektie);
-    document.getElementById('metqi').innerText   = formatNumber(metqi);
+    updateResult('medeb', formatNumber(medeb));
+    updateResult('wenber', formatNumber(wenber));
+    updateResult('abektie', formatNumber(abektie));
+    updateResult('metqi', formatNumber(metqi));
 
     // Step 5: Calculate Beale Metqi
     let bealeMetqiMonth, ninevehMonth, bealeMetqiDay;
@@ -116,7 +123,7 @@ function calculateCalendar() {
     // Shift Beale Metqi Day of the Week to the Previous Day
     //bealeMetqiDayOfWeek = shiftDayToPrevious(bealeMetqiDayOfWeek);
 
-    document.getElementById('bealeMetqi').innerText = `${mapMonthToAmharic(bealeMetqiMonth)} ${formatNumber(bealeMetqiDay)} (${mapWeekDaysToAmharic(bealeMetqiDayOfWeek)})`;
+    updateResult('bealeMetqi', `${mapMonthToAmharic(bealeMetqiMonth)} ${formatNumber(bealeMetqiDay)} (${mapWeekDaysToAmharic(bealeMetqiDayOfWeek)})`);
 
     // Step 7: Lookup the Tewsak for the adjusted day of the week
     const tewsakTable = {
@@ -137,7 +144,7 @@ function calculateCalendar() {
         mebajaHamer -= 30;  // Adjust if it exceeds 30 days
         ninevehMonth = "Yekatit"; // Move Nineveh to the next month
     }
-    document.getElementById('mebajaHamer').innerText = `${mapMonthToAmharic(ninevehMonth)} ${formatNumber(mebajaHamer)}`;
+    updateResult('mebajaHamer', `${mapMonthToAmharic(ninevehMonth)} ${formatNumber(mebajaHamer)}`);
 
     // Step 9: Calculate fasting and holy days based on Nineveh
     const fastingDates = calculateFastingDates(ninevehMonth, mebajaHamer);


### PR DESCRIPTION
## Summary
- show calculated values in a grid of cards instead of a table
- add `updateResult` helper and use it in calculations

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a6f3eee4c83209ac7e34b6e583525