### PR TITLE
Reduce vertical space for info cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,15 @@
             background-color: #f8d7da;
             color: red;
         }
+        .small-card .card-body {
+            padding: 0.5rem;
+        }
+        .small-card .card-title {
+            font-size: 1rem;
+        }
+        .small-card .card-text {
+            font-size: 0.9rem;
+        }
     </style>
 </head>
 <body>
@@ -65,7 +74,7 @@
 
         <div class="row mt-4" id="resultCards">
             <div class="col-sm-6 col-lg-4 mb-3">
-                <div class="card h-100">
+                <div class="card small-card">
                     <div class="card-body">
                         <h5 class="card-title">ዓመተ አለም</h5>
                         <p class="card-text" id="ameteAlem"></p>
@@ -73,7 +82,7 @@
                 </div>
             </div>
             <div class="col-sm-6 col-lg-4 mb-3">
-                <div class="card h-100">
+                <div class="card small-card">
                     <div class="card-body">
                         <h5 class="card-title">ወንጌላዊ</h5>
                         <p class="card-text" id="wengelawi"></p>
@@ -81,7 +90,7 @@
                 </div>
             </div>
             <div class="col-sm-6 col-lg-4 mb-3">
-                <div class="card h-100">
+                <div class="card small-card">
                     <div class="card-body">
                         <h5 class="card-title">እንቁጣጣሽ</h5>
                         <p class="card-text" id="tinteQemer"></p>
@@ -89,7 +98,7 @@
                 </div>
             </div>
             <div class="col-sm-6 col-lg-4 mb-3">
-                <div class="card h-100">
+                <div class="card small-card">
                     <div class="card-body">
                         <h5 class="card-title">መደብ</h5>
                         <p class="card-text" id="medeb"></p>
@@ -97,7 +106,7 @@
                 </div>
             </div>
             <div class="col-sm-6 col-lg-4 mb-3">
-                <div class="card h-100">
+                <div class="card small-card">
                     <div class="card-body">
                         <h5 class="card-title">ወንበር</h5>
                         <p class="card-text" id="wenber"></p>
@@ -105,7 +114,7 @@
                 </div>
             </div>
             <div class="col-sm-6 col-lg-4 mb-3">
-                <div class="card h-100">
+                <div class="card small-card">
                     <div class="card-body">
                         <h5 class="card-title">አበቅቴ</h5>
                         <p class="card-text" id="abektie"></p>
@@ -113,7 +122,7 @@
                 </div>
             </div>
             <div class="col-sm-6 col-lg-4 mb-3">
-                <div class="card h-100">
+                <div class="card small-card">
                     <div class="card-body">
                         <h5 class="card-title">መጥቅእ</h5>
                         <p class="card-text" id="metqi"></p>
@@ -121,7 +130,7 @@
                 </div>
             </div>
             <div class="col-sm-6 col-lg-4 mb-3">
-                <div class="card h-100">
+                <div class="card small-card">
                     <div class="card-body">
                         <h5 class="card-title">በዓለ መጥቅእ</h5>
                         <p class="card-text" id="bealeMetqi"></p>
@@ -129,7 +138,7 @@
                 </div>
             </div>
             <div class="col-sm-6 col-lg-4 mb-3">
-                <div class="card h-100">
+                <div class="card small-card">
                     <div class="card-body">
                         <h5 class="card-title">መባጃ ሐመር(ነነዌ)</h5>
                         <p class="card-text" id="mebajaHamer"></p>


### PR DESCRIPTION
## Summary
- shrink result cards with new `.small-card` style
- swap Bootstrap `h-100` class for `.small-card` on the first nine cards
- keep the calendar card unchanged

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ae8d95ea88320ab8998a943a8059b